### PR TITLE
Add buffer flags, fix delimiters

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,6 +32,7 @@ clang \
 	-Wl,--export=hb_buffer_guess_segment_properties \
 	-Wl,--export=hb_buffer_set_direction \
 	-Wl,--export=hb_buffer_set_cluster_level \
+	-Wl,--export=hb_buffer_set_flags \
 	-Wl,--export=hb_buffer_set_script \
 	-Wl,--export=hb_script_from_string \
 	-Wl,--export=hb_buffer_set_language \

--- a/hbjs.c
+++ b/hbjs.c
@@ -199,7 +199,7 @@ static hb_bool_t do_trace (hb_buffer_t *buffer,
 
   _strcat(user_data, "{\"m\":\"");
   _strcat(user_data, message);
-  _strcat(user_data, "\",\"t\":[");
+  _strcat(user_data, "\",\"t\":");
   hb_buffer_serialize_glyphs(buffer, 0, num_glyphs,
     user_data->str + user_data->consumed,
     user_data->size - user_data->consumed,
@@ -208,7 +208,7 @@ static hb_bool_t do_trace (hb_buffer_t *buffer,
     HB_BUFFER_SERIALIZE_FORMAT_JSON,
     HB_BUFFER_SERIALIZE_FLAG_NO_GLYPH_NAMES);
   user_data->consumed += consumed;
-  _strcat(user_data, "]},\n");
+  _strcat(user_data, "},\n");
 
 
   return 1;

--- a/hbjs.js
+++ b/hbjs.js
@@ -18,6 +18,15 @@ function hbjs(instance) {
     )
   }
 
+  function _buffer_flag(s) {
+    if (s == "BOT") { return 0x1; }
+    if (s == "EOT") { return 0x2; }
+    if (s == "PRESERVE_DEFAULT_IGNORABLES") { return 0x4; }
+    if (s == "REMOVE_DEFAULT_IGNORABLES") { return 0x8; }
+    if (s == "DO_NOT_INSERT_DOTTED_CIRCLE") { return 0x10; }
+    return 0x0;
+  }
+
   /**
   * Create an object representing a Harfbuzz blob.
   * @param {string} blob A blob of binary data (usually the contents of a font file).
@@ -163,6 +172,23 @@ function hbjs(instance) {
           ttb: 6,
           btt: 7
         }[dir] || 0);
+      },
+      /**
+      * Set buffer flags explicitly.
+      * @param {string[]} flags: A list of strings which may be either:
+      * "BOT"
+      * "EOT"
+      * "PRESERVE_DEFAULT_IGNORABLES"
+      * "REMOVE_DEFAULT_IGNORABLES"
+      * "DO_NOT_INSERT_DOTTED_CIRCLE"
+      */
+      setFlags: function (flags) {
+        var flagValue = 0
+        flags.forEach(function (s) {
+          flagValue |= _buffer_flag(s);
+        })
+
+        exports.hb_buffer_set_flags(ptr,flagValue);
       },
       /**
       * Set buffer language explicitly.


### PR DESCRIPTION
This allows setting buffer flags from Javascript. However, when writing it I also noticed that we need a change to hbjs's shape_with_trace. This is because `hb_buffer_serialize_glyphs` now writes the array delimiters ([]) on JSON output for us, so we do not need to add them ourselves. So even if you don't want the buffer flags fix, you want to merge bf84c11.