### PR TITLE
Change the buffer to use UTF16

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -29,6 +29,7 @@ clang \
 	-Wl,--export=hb_font_create \
 	-Wl,--export=hb_buffer_create \
 	-Wl,--export=hb_buffer_add_utf8 \
+	-Wl,--export=hb_buffer_add_utf16 \
 	-Wl,--export=hb_buffer_guess_segment_properties \
 	-Wl,--export=hb_buffer_set_direction \
 	-Wl,--export=hb_buffer_set_cluster_level \

--- a/hbjs.js
+++ b/hbjs.js
@@ -137,6 +137,17 @@ function hbjs(instance) {
     };
   }
 
+  function createJsString(text) {
+    const ptr = exports.malloc(text.length * 2);
+    const words = new Uint16Array(exports.memory.buffer, ptr, text.length);
+    for (let i = 0; i < words.length; ++i) words[i] = text.charCodeAt(i);
+    return {
+      ptr: ptr,
+      length: words.length,
+      free: function () { exports.free(ptr); }
+    };
+  }
+
   /**
   * Create an object representing a Harfbuzz buffer.
   **/
@@ -149,8 +160,8 @@ function hbjs(instance) {
       * @param {string} text Text to be added to the buffer.
       **/
       addText: function (text) {
-        var str = createCString(text);
-        exports.hb_buffer_add_utf8(ptr, str.ptr, str.length, 0, str.length);
+        const str = createJsString(text);
+        exports.hb_buffer_add_utf16(ptr, str.ptr, str.length, 0, str.length);
         str.free();
       },
       /**


### PR DESCRIPTION
Since HarfBuzz outputs cluster indices into the original array you passed it, I'd like to propose that hbjs use UTF-16 buffers. The UTF-8 buffer that it currently uses produces cluster indices that don't map correctly to the JavaScript string that was passed to hbjs.