### PR TITLE
Expose hb_set_{clear,invert} in hb-subset.wasm

### DIFF
--- a/subset/build.sh
+++ b/subset/build.sh
@@ -19,8 +19,10 @@ clang \
 	-Wl,--export=hb_face_create \
 	-Wl,--export=hb_set_create \
 	-Wl,--export=hb_set_add \
+	-Wl,--export=hb_set_clear \
 	-Wl,--export=hb_set_del \
 	-Wl,--export=hb_set_destroy \
+	-Wl,--export=hb_set_invert \
 	-Wl,--export=hb_set_union \
 	-Wl,--export=hb_face_reference_blob \
 	-Wl,--export=hb_blob_get_data \


### PR DESCRIPTION
Required for simulating `--layout-features=*`

More context: https://github.com/papandreou/subset-font/pull/13#issuecomment-964644789