### PR TITLE
Fix: Destroy the right pointer in `collectUnicodes`

### DIFF
--- a/hbjs.js
+++ b/hbjs.js
@@ -142,7 +142,7 @@ function hbjs(instance) {
         var unicodeSetPtr = exports.hb_set_create();
         exports.hb_face_collect_unicodes(ptr, unicodeSetPtr);
         var result = typedArrayFromSet(unicodeSetPtr, Uint32Array);
-        exports.hb_set_destroy(ptr);
+        exports.hb_set_destroy(unicodeSetPtr);
         return result;
       },
       /**


### PR DESCRIPTION
Right now `face.collectUnicodes` creates a temporary set, but frees the pointer holding the face itself instead of the temporary set at the end -- probably a copy/paste error. This leads to `RuntimeError: memory access out of bounds` when using the face after that.