### PR TITLE
Update shape_with_trace to new logging messages

### DIFF
--- a/hbjs.cc
+++ b/hbjs.cc
@@ -153,9 +153,9 @@ static hb_bool_t do_trace (hb_buffer_t *buffer,
   unsigned int consumed;
   unsigned int num_glyphs = hb_buffer_get_length (buffer);
 
-  if (strcmp(message, "start table GSUB") == 0) {
+  if (strncmp(message, "start table GSUB", 16) == 0) {
     user_data->current_phase = HB_SHAPE_GSUB_PHASE;
-  } else if (strcmp(message, "start table GPOS") == 0) {
+  } else if (strncmp(message, "start table GPOS", 16) == 0) {
     user_data->current_phase = HB_SHAPE_GPOS_PHASE;
   }
 
@@ -170,10 +170,10 @@ static hb_bool_t do_trace (hb_buffer_t *buffer,
   if (user_data->stop_phase != HB_SHAPE_DONT_STOP) {
     // Do we need to start stopping?
     char buf[12];
-    snprintf (buf, 12, "%d", user_data->stop_at);
+    snprintf (buf, 12, "%d ", user_data->stop_at);
     if ((user_data->current_phase == user_data->stop_phase) &&
         (strncmp(message, "end lookup ", 11) == 0) &&
-        (strcmp(message + 11, buf) == 0)) {
+        (strncmp(message + 11, buf, strlen(buf)) == 0)) {
       user_data->stopping = true;
     }
   }


### PR DESCRIPTION
The partial tracing feature of shape_with_trace is dependent on matching the text of certain log messages to know when to stop shaping. These messages have recently been rewritten (with more useful information!) but harfbuzzjs has not kept up to date.