### PR TITLE
fix: subset needs to support vertical layout

### DIFF
--- a/config-override-subset.h
+++ b/config-override-subset.h
@@ -4,3 +4,4 @@
 #undef HB_NO_SUBSET_LAYOUT
 #undef HB_NO_VAR
 #undef HB_NO_STYLE
+#undef HB_NO_VERTICAL


### PR DESCRIPTION
Both hb-subset and fonttools have subsetized vertical layout turned on by default, so keep it the same here.

![image](https://github.com/harfbuzz/harfbuzzjs/assets/2784308/40217677-09a3-4e88-af59-8660d3512e9f)

Closes: https://github.com/harfbuzz/harfbuzzjs/issues/92