### PR TITLE
Expose the `hb_subset_input_set_axis_range` function in the `hb-subset` build

### DIFF
--- a/hb-subset.symbols
+++ b/hb-subset.symbols
@@ -22,6 +22,7 @@ _hb_subset_input_pin_axis_location
 _hb_subset_input_pin_axis_to_default
 _hb_subset_input_reference
 _hb_subset_input_set
+_hb_subset_input_set_axis_range
 _hb_subset_input_set_flags
 _hb_subset_input_set_user_data
 _hb_subset_input_unicode_set


### PR DESCRIPTION
Include the `hb_subset_input_set_axis_range` function that [was released](https://github.com/harfbuzz/harfbuzz/blob/cc67579c8ed2fe3305117d15d101682ffe0a84b7/NEWS#L103-L142) in Harfbuzz 8.0.0.

I would like this function so I can add support for axis trimming of variable fonts to the [subset-font](https://github.com/papandreou/subset-font) and [subfont](https://github.com/Munter/subfont) projects.