### PR TITLE
Add hb_version symbol and .version member

### DIFF
--- a/hb.symbols
+++ b/hb.symbols
@@ -46,5 +46,6 @@ _hb_set_get_population
 _hb_set_next_many
 _hb_shape
 _hb_version
+_hb_version_string
 _malloc
 _free

--- a/hb.symbols
+++ b/hb.symbols
@@ -45,5 +45,6 @@ _hb_set_destroy
 _hb_set_get_population
 _hb_set_next_many
 _hb_shape
+_hb_version
 _malloc
 _free

--- a/hbjs.js
+++ b/hbjs.js
@@ -533,15 +533,34 @@ function hbjs(Module) {
     return trace;
   }
 
+  function get_version() {
+    var major = exports.malloc(4);
+    var minor = exports.malloc(4);
+    var patch = exports.malloc(4);
+    heapu32[major / 4] = 0;
+    heapu32[minor / 4] = 0;
+    heapu32[patch / 4] = 0;
+    exports.hb_version(major, minor, patch);
+    let hbversion =
+      heapu32[major / 4] + "." + heapu32[minor / 4] + "." + heapu32[patch / 4];
+    exports.free(major);
+    exports.free(minor);
+    exports.free(patch);
+    return hbversion;
+  }
+
   return {
     createBlob: createBlob,
     createFace: createFace,
     createFont: createFont,
     createBuffer: createBuffer,
     shape: shape,
-    shapeWithTrace: shapeWithTrace
+    shapeWithTrace: shapeWithTrace,
+    version: get_version(),
   };
-};
+}
 
 // Should be replaced with something more reliable
-try { module.exports = hbjs; } catch(e) {}
+try {
+  module.exports = hbjs;
+} catch (e) {}

--- a/hbjs.js
+++ b/hbjs.js
@@ -534,19 +534,9 @@ function hbjs(Module) {
   }
 
   function get_version() {
-    var major = exports.malloc(4);
-    var minor = exports.malloc(4);
-    var patch = exports.malloc(4);
-    heapu32[major / 4] = 0;
-    heapu32[minor / 4] = 0;
-    heapu32[patch / 4] = 0;
-    exports.hb_version(major, minor, patch);
-    let hbversion =
-      heapu32[major / 4] + "." + heapu32[minor / 4] + "." + heapu32[patch / 4];
-    exports.free(major);
-    exports.free(minor);
-    exports.free(patch);
-    return hbversion;
+    var versionPtr = exports.hb_version_string();
+    var version = utf8Decoder.decode(heapu8.subarray(versionPtr, heapu8.indexOf(0, versionPtr)));
+    return version;
   }
 
   return {

--- a/test/index.js
+++ b/test/index.js
@@ -247,3 +247,10 @@ describe('shape', function () {
     });
   });
 });
+
+describe('misc', function () {
+  it('get version string', function () {
+    const version = hb.version
+    expect(version).to.match(/^\d+\.\d+\.\d+$/);
+  });
+});


### PR DESCRIPTION
This patch allows `hbjs.version` to return (as a string) the version number of Harfbuzz being used.