### PR TITLE
Fix browser JavaScript issues loading hb.wasm and add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,11 +43,18 @@ RUN set -x \
   && nvm alias default $NODE_VERSION \
   && nvm use default \
   && node -v \
-  && npm -v \
-  && npm i -g mocha@10.8.2 \
-  && npm i -g chai@4.5.0 \
-  && npm i -g typescript@5.7.2 \
-  && npm i -g pad.js
+  && npm -v
+
+#-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!
+# chai (and mocha) need to be installed locally!
+# chai CANNOT be found if only installed globally :-(
+#
+# *INSTEAD* Use ./npm-install.sh
+# This creates ./node_modules in the current app directory
+# and downloads all the required npm modules for `npm test`
+# Only needs to be called once within the docker container.
+#-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!
+
 
 # Essential to get EM++ to work!
 # (From terminal this is set in the `source ./emsdk_env.sh` script)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+FROM ubuntu:22.04
+
+#---------------------------------------------
+# See: https://github.com/harfbuzz/harfbuzzjs
+#---------------------------------------------
+
+SHELL ["/bin/bash", "-c"]
+
+ENV NVM_DIR=/build/nvm
+ENV NVM_VERSION=0.40.1
+ENV NODE_VERSION=18.4.0
+ENV EMSDK_VERSION=3.1.56
+
+# for `npx pad.js`
+EXPOSE 9090/tcp
+
+# Update the $PATH to make your installed `node` and `npm` available!
+ENV PATH=$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+
+RUN apt update -y \
+  && apt upgrade -y
+
+RUN apt install -y \
+  git \
+  nodejs \
+  python3 \
+  xz-utils \
+  cmake curl \
+  binaryen
+
+RUN set -x \
+  && cd / \
+  && git clone https://github.com/emscripten-core/emsdk.git \
+  && cd emsdk \
+  && git pull \
+  && ./emsdk install $EMSDK_VERSION \
+  && ./emsdk activate $EMSDK_VERSION \
+  && source ./emsdk_env.sh \
+  && mkdir -p $NVM_DIR \
+  && curl https://raw.githubusercontent.com/creationix/nvm/v$NVM_VERSION/install.sh | bash \
+  && . $NVM_DIR/nvm.sh \
+  && nvm install $NODE_VERSION \
+  && nvm alias default $NODE_VERSION \
+  && nvm use default \
+  && node -v \
+  && npm -v \
+  && npm i -g mocha@10.8.2 \
+  && npm i -g chai@4.5.0 \
+  && npm i -g typescript@5.7.2 \
+  && npm i -g pad.js
+
+# Essential to get EM++ to work!
+# (From terminal this is set in the `source ./emsdk_env.sh` script)
+ENV PATH=/emsdk/upstream/emscripten:/emsdk:$PATH
+
+WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -9,23 +9,28 @@ See the demo [here](https://harfbuzz.github.io/harfbuzzjs/).
 2. `./build.sh`
 
 ### Using Docker
-Install Docker and use the following commands to build the Docker container, and run.
+Install Docker Desktop and use the following commands from a command prompt to build the Docker container, and run.
 
 The Dockerfile contains a complete set of tools to build and test harfbuzzjs.
 
 Linux:
 1. `docker build ./ -t harfbuzzjs:0.4.3`
 2. `docker run --rm -it -v $PWD:/app -w /app harfbuzzjs:0.4.3`
-3. Then, inside the temporary Linux terminal, use `./build.sh` and `npm test`
 
 Windows CMD prompt:
 1. `docker build ./ -t harfbuzzjs:0.4.3`
 2. `docker run --rm -it -v %cd%:/app -w /app harfbuzzjs:0.4.3`
-3. Then, inside the temporary Linux terminal, use `./build.sh` and `npm test`
 
 Two .cmd files are provided for ease `build-docker.cmd` and `run-docker.cmd`.
 
 NOTE: if using PowerShell, replace `%cd%` with `${PWD}`.
+
+Inside the Linux docker:
+1. Build the wasm: `./build.sh`
+2. Testing:
+ - (once) `./npm-install.sh` This creates `./node_modules` in the harfbuzzjs directory with all the required NodeJS modules
+ - `npm test` - runs the tests
+
 
 ## Download
 Download the pack from [releases tab](https://github.com/harfbuzz/harfbuzzjs/releases)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,25 @@ See the demo [here](https://harfbuzz.github.io/harfbuzzjs/).
 1. Install emscripten
 2. `./build.sh`
 
+### Using Docker
+Install Docker and use the following commands to build the Docker container, and run.
+
+The Dockerfile contains a complete set of tools to build and test harfbuzzjs.
+
+Linux:
+1. `docker build ./ -t harfbuzzjs:0.4.3`
+2. `docker run --rm -it -v $PWD:/app -w /app harfbuzzjs:0.4.3`
+3. Then, inside the temporary Linux terminal, use `./build.sh` and `npm test`
+
+Windows CMD prompt:
+1. `docker build ./ -t harfbuzzjs:0.4.3`
+2. `docker run --rm -it -v %cd%:/app -w /app harfbuzzjs:0.4.3`
+3. Then, inside the temporary Linux terminal, use `./build.sh` and `npm test`
+
+Two .cmd files are provided for ease `build-docker.cmd` and `run-docker.cmd`.
+
+NOTE: if using PowerShell, replace `%cd%` with `${PWD}`.
+
 ## Download
 Download the pack from [releases tab](https://github.com/harfbuzz/harfbuzzjs/releases)
 of the project, or just download the [demo page](https://harfbuzz.github.io/harfbuzzjs/) (the
@@ -17,6 +36,7 @@ demo source is in [gh-pages](https://github.com/harfbuzz/harfbuzzjs/tree/gh-page
 
 ### TL;DR
 
+NodeJS:
 ```javascript
 hb = require("hbjs.js")
 WebAssembly.instantiateStreaming(fetch("hb.wasm")).then(function (result) {

--- a/build-docker.cmd
+++ b/build-docker.cmd
@@ -1,0 +1,2 @@
+rem Windows Docker build
+docker build ./ -t harfbuzzjs:0.4.3

--- a/build.sh
+++ b/build.sh
@@ -16,6 +16,7 @@ em++ \
 	-DHB_EXPERIMENTAL_API \
 	--no-entry \
 	-s MODULARIZE \
+	-s EXPORT_NAME=createHarfBuzz \
 	-s EXPORTED_FUNCTIONS=@hb.symbols \
 	-s EXPORTED_RUNTIME_METHODS='["addFunction", "wasmMemory", "wasmExports"]' \
 	-s INITIAL_MEMORY=65MB \

--- a/examples/hbjs.example.html
+++ b/examples/hbjs.example.html
@@ -1,12 +1,15 @@
+<script src="../hb.js"></script>
 <script src="../hbjs.js"></script>
 <script src="hbjs.example.js"></script>
 <script>
-// instantiateStreaming isn't supported in Safari yet, see nohbjs.html
-WebAssembly.instantiateStreaming(fetch("../hb.wasm")).then(function (result) {
+
+let harfBuzzModule; // not really needed with the hbjs wrapper
+createHarfBuzz().then(hbmodule=>{
+  harfBuzzModule = hbmodule;
   fetch('../test/fonts/noto/NotoSans-Regular.ttf').then(function (x) {
     return x.arrayBuffer();
   }).then(function (blob) {
-    document.body.innerText = JSON.stringify(example(hbjs(result.instance), new Uint8Array(blob)), undefined, 2);
+    document.body.innerText = JSON.stringify(example(hbjs(hbmodule), new Uint8Array(blob)), undefined, 2);
     document.body.style.whiteSpace = 'pre';
   });
 });

--- a/examples/nohbjs.html
+++ b/examples/nohbjs.html
@@ -1,15 +1,12 @@
 <!DOCTYPE html>
+<script src="../hb.js"></script>
 <script>
 var utf8Encoder = new TextEncoder("utf8");
 
-// We could use instantiateStreaming but it's not supported in Safari yet
-// https://bugs.webkit.org/show_bug.cgi?id=173105
-fetch("../hb.wasm").then(function (x) {
-  return x.arrayBuffer();
-}).then(function (wasm) {
-  return WebAssembly.instantiate(wasm);
-}).then(function (result) {
-  var exports = result.instance.exports;
+let harfBuzzModule;
+createHarfBuzz().then(hbmodule=>{
+  harfBuzzModule = hbmodule;
+  var exports = hbmodule.wasmExports;
 
   fetch('../test/fonts/noto/NotoSans-Regular.ttf').then(function (x) {
     return x.arrayBuffer();

--- a/npm-install.sh
+++ b/npm-install.sh
@@ -1,0 +1,6 @@
+# Install all required npm modules
+# so that `npm test` will run
+npm i mocha@10.8.2 \
+	&& npm i chai@4.5.0 \
+	&& npm i typescript@5.7.2 \
+	&& npm i pad.js

--- a/run-docker.cmd
+++ b/run-docker.cmd
@@ -1,0 +1,4 @@
+rem Windows Docker run
+rem NOTE: `/app` within Linux will be this directory in Windows
+rem       so it emits the build straight to Windows without any other operation
+docker run --rm -it -v %cd%:/app -w /app harfbuzzjs:0.4.3


### PR DESCRIPTION
Since v0.4.x the emscripten options have included `-s MODULARIZE`.
This breaks the original loading mechanism used in 0.3.6. (NodeJS always worked)

Now, the `hb.js` is always required - this provides the module load - and `hbjs.js` is optional.

The two sample html files have been fixed to use the new module-based load mechanism (note: the Demo repo is separate).

Additionally, a Dockerfile was created to ease development on Windows (and to standardise for other platforms).
Forgot to mention in the README that Ctrl-D quits the temporary Docker Linux console.

Thank you!