### PR TITLE
Fix browser issues with 0.4.x

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,6 +16,7 @@ em++ \
 	-DHB_EXPERIMENTAL_API \
 	--no-entry \
 	-s MODULARIZE \
+	-s EXPORT_NAME=createHarfBuzz \
 	-s EXPORTED_FUNCTIONS=@hb.symbols \
 	-s EXPORTED_RUNTIME_METHODS='["addFunction", "wasmMemory", "wasmExports"]' \
 	-s INITIAL_MEMORY=65MB \

--- a/examples/hbjs.example.html
+++ b/examples/hbjs.example.html
@@ -1,12 +1,15 @@
+<script src="../hb.js"></script>
 <script src="../hbjs.js"></script>
 <script src="hbjs.example.js"></script>
 <script>
-// instantiateStreaming isn't supported in Safari yet, see nohbjs.html
-WebAssembly.instantiateStreaming(fetch("../hb.wasm")).then(function (result) {
+
+let harfBuzzModule; // not really needed with the hbjs wrapper
+createHarfBuzz().then(hbmodule=>{
+  harfBuzzModule = hbmodule;
   fetch('../test/fonts/noto/NotoSans-Regular.ttf').then(function (x) {
     return x.arrayBuffer();
   }).then(function (blob) {
-    document.body.innerText = JSON.stringify(example(hbjs(result.instance), new Uint8Array(blob)), undefined, 2);
+    document.body.innerText = JSON.stringify(example(hbjs(hbmodule), new Uint8Array(blob)), undefined, 2);
     document.body.style.whiteSpace = 'pre';
   });
 });

--- a/examples/nohbjs.html
+++ b/examples/nohbjs.html
@@ -1,15 +1,12 @@
 <!DOCTYPE html>
+<script src="../hb.js"></script>
 <script>
 var utf8Encoder = new TextEncoder("utf8");
 
-// We could use instantiateStreaming but it's not supported in Safari yet
-// https://bugs.webkit.org/show_bug.cgi?id=173105
-fetch("../hb.wasm").then(function (x) {
-  return x.arrayBuffer();
-}).then(function (wasm) {
-  return WebAssembly.instantiate(wasm);
-}).then(function (result) {
-  var exports = result.instance.exports;
+let harfBuzzModule;
+createHarfBuzz().then(hbmodule=>{
+  harfBuzzModule = hbmodule;
+  var exports = hbmodule.wasmExports;
 
   fetch('../test/fonts/noto/NotoSans-Regular.ttf').then(function (x) {
     return x.arrayBuffer();


### PR DESCRIPTION
Fixed the example .html files.

Since v0.4.x the emscripten options have included `-s MODULARIZE`.
This breaks the original loading mechanism used in 0.3.6. (NodeJS always worked)

Now, the `hb.js` is always required - this provides the module load - and `hbjs.js` is still optional.

The two sample html files have been fixed to use the new module-based load mechanism (note: the Demo repo is separate).