### PR TITLE
Reduce initial WASM memory and auto-grow it

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,7 +19,8 @@ em++ \
 	-s EXPORT_NAME=createHarfBuzz \
 	-s EXPORTED_FUNCTIONS=@hb.symbols \
 	-s EXPORTED_RUNTIME_METHODS='["addFunction", "removeFunction", "wasmMemory", "wasmExports"]' \
-	-s INITIAL_MEMORY=65MB \
+	-s INITIAL_MEMORY=256KB \
+	-s ALLOW_MEMORY_GROWTH \
 	-s ALLOW_TABLE_GROWTH \
 	-lexports.js \
 	-o hb.js \


### PR DESCRIPTION
Emscripten updates the views it exposes (`Module.HEAPU8` etc) whenever memory resizes so, compiler flags aside, all this does is remove aliasing. We can still have aliases, but they have to be re-created after any calls that could have resized memory. It's easier and safer to just write the whole thing out, and JS engines are really good at inline caching anyways. 

Fixes #117