### PR TITLE
Add optional itemOffset/itemLength to buffer.addText()/addCodepoints()

### DIFF
--- a/hbjs.js
+++ b/hbjs.js
@@ -904,21 +904,27 @@ function hbjs(Module) {
       /**
       * Add text to the buffer.
       * @param {string} text Text to be added to the buffer.
+      * @param {number} itemOffset Optional. The offset of the first character to add to the buffer.
+      * @param {number} itemLength Optional. The number of characters to add to the buffer, or null for the end of text.
       **/
-      addText: function (text) {
+      addText: function (text, itemOffset = 0, itemLength = null) {
         const str = createJsString(text);
-        exports.hb_buffer_add_utf16(ptr, str.ptr, str.length, 0, str.length);
+        if (itemLength == null) itemLength = str.length;
+        exports.hb_buffer_add_utf16(ptr, str.ptr, str.length, itemOffset, itemLength);
         str.free();
       },
       /**
       * Add code points to the buffer.
       * @param {number[]} codePoints Array of code points to be added to the buffer.
+      * @param {number} itemOffset Optional. The offset of the first code point to add to the buffer.
+      * @param {number} itemLength Optional. The number of code points to add to the buffer, or null for the end of the array.
       */
-      addCodePoints: function (codePoints) {
+      addCodePoints: function (codePoints, itemOffset = 0, itemLength = null) {
         let codePointsPtr = exports.malloc(codePoints.length * 4);
         let codePointsArray = new Uint32Array(Module.wasmMemory.buffer, codePointsPtr, codePoints.length);
         codePointsArray.set(codePoints);
-        exports.hb_buffer_add_codepoints(ptr, codePointsPtr, codePoints.length, 0, codePoints.length);
+        if (itemLength == null) itemLength = codePoints.length;
+        exports.hb_buffer_add_codepoints(ptr, codePointsPtr, codePoints.length, itemOffset, itemLength);
         exports.free(codePointsPtr);
       },
       /**

--- a/test/index.js
+++ b/test/index.js
@@ -615,6 +615,32 @@ describe('shape', function () {
     expect(glyphs[3]).to.deep.equal({ cl: 0, g: 50, ax: 235, ay: 0, dx: 0, dy: 0, flags: 0 } /* أ */);
   });
 
+  it('shape Arabic string item', function () {
+    blob = hb.createBlob(fs.readFileSync(path.join(__dirname, 'fonts/noto/NotoSansArabic-Variable.ttf')));
+    face = hb.createFace(blob);
+    font = hb.createFont(face);
+    buffer = hb.createBuffer();
+    buffer.addText('أبجد', 1, 2);
+    buffer.guessSegmentProperties();
+    hb.shape(font, buffer)
+    const glyphs = buffer.json();
+    expect(glyphs[0]).to.deep.equal({ cl: 2, g: 529, ax: 637, ay: 0, dx: 0, dy: 0, flags: 1 } /* ج */);
+    expect(glyphs[1]).to.deep.equal({ cl: 1, g: 101, ax: 269, ay: 0, dx: 0, dy: 0, flags: 0 } /* ب */);
+  });
+
+  it('shape Arabic code points item', function () {
+    blob = hb.createBlob(fs.readFileSync(path.join(__dirname, 'fonts/noto/NotoSansArabic-Variable.ttf')));
+    face = hb.createFace(blob);
+    font = hb.createFont(face);
+    buffer = hb.createBuffer();
+    buffer.addCodePoints([...'أبجد'].map(c => c.codePointAt(0)), 1, 2);
+    buffer.guessSegmentProperties();
+    hb.shape(font, buffer)
+    const glyphs = buffer.json();
+    expect(glyphs[0]).to.deep.equal({ cl: 2, g: 529, ax: 637, ay: 0, dx: 0, dy: 0, flags: 1 } /* ج */);
+    expect(glyphs[1]).to.deep.equal({ cl: 1, g: 101, ax: 269, ay: 0, dx: 0, dy: 0, flags: 0 } /* ب */);
+  });
+
   it('shape with tracing', function () {
     blob = hb.createBlob(fs.readFileSync(path.join(__dirname, 'fonts/noto/NotoSans-Regular.ttf')));
     face = hb.createFace(blob);


### PR DESCRIPTION
To allow shaping s substring (item) of longer text, like the underlying HarfBuzz C API.