### PR TITLE
Make buffer.serialize() flag names consistent with buffer.setFlags()

### DIFF
--- a/hbjs.js
+++ b/hbjs.js
@@ -40,7 +40,9 @@ function hbjs(Module) {
     "PRESERVE_DEFAULT_IGNORABLES": 0x00000004,
     "REMOVE_DEFAULT_IGNORABLES": 0x00000008,
     "DO_NOT_INSERT_DOTTED_CIRCLE": 0x00000010,
+    "VERIFY": 0x00000020,
     "PRODUCE_UNSAFE_TO_CONCAT": 0x00000040,
+    "PRODUCE_SAFE_TO_INSERT_TATWEEL": 0x00000080,
   };
 
   function _hb_tag(s) {
@@ -1016,7 +1018,9 @@ function hbjs(Module) {
       * "PRESERVE_DEFAULT_IGNORABLES"
       * "REMOVE_DEFAULT_IGNORABLES"
       * "DO_NOT_INSERT_DOTTED_CIRCLE"
+      * "VERIFY"
       * "PRODUCE_UNSAFE_TO_CONCAT"
+      * "PRODUCE_SAFE_TO_INSERT_TATWEEL"
       */
       setFlags: function (flags) {
         var flagsValue = 0

--- a/test/index.js
+++ b/test/index.js
@@ -583,6 +583,28 @@ describe('Buffer', function () {
     expect(glyphs[0].g).to.equal(68 /* a */);
   });
 
+  it('setFlags with PRODUCE_SAFE_TO_INSERT_TATWEEL affects glyph flags', function () {
+    blob = hb.createBlob(fs.readFileSync(path.join(__dirname, 'fonts/noto/NotoSansArabic-Variable.ttf')));
+    face = hb.createFace(blob);
+    font = hb.createFont(face);
+    buffer = hb.createBuffer();
+    buffer.addText('بلا');
+    buffer.setFlags(['PRODUCE_SAFE_TO_INSERT_TATWEEL']);
+    buffer.guessSegmentProperties();
+    hb.shape(font, buffer)
+    const flags = Array.from(buffer.json().map(g => g.flags));
+    expect(flags).to.deep.equal([5, 0]);
+    buffer.destroy();
+
+    buffer = hb.createBuffer();
+    buffer.addText('بلا');
+    buffer.setFlags([]);
+    buffer.guessSegmentProperties();
+    hb.shape(font, buffer)
+    const flags2 = Array.from(buffer.json().map(g => g.flags));
+    expect(flags2).to.deep.equal([1, 0]);
+  });
+
   it('serialize ignores invalid flags', function () {
     blob = hb.createBlob(fs.readFileSync(path.join(__dirname, 'fonts/noto/NotoSans-Regular.ttf')));
     face = hb.createFace(blob);


### PR DESCRIPTION
buffer.setFlags() accepts upper case names similar to HarfBuzz C API, so make the new buffer.serialize() do the same for consistency.