### PR TITLE
Expose private glyph info and position members

### DIFF
--- a/hbjs.js
+++ b/hbjs.js
@@ -1118,10 +1118,17 @@ function hbjs(Module) {
         var infosArray = Module.HEAPU32.subarray(infosPtr32, infosPtr32 + this.getLength() * 5);
         var infos = [];
         for (var i = 0; i < infosArray.length; i += 5) {
-          infos.push({
+          var info = {
             codepoint: infosArray[i],
             cluster: infosArray[i + 2],
-          });
+          };
+          for (var [name, idx] of [['mask', 1], ['var1', 3], ['var2', 4]]) {
+            Object.defineProperty(info, name, {
+              value: infosArray[i + idx],
+              enumerable: false
+            });
+          }
+          infos.push(info);
         }
         return infos;
       },
@@ -1146,12 +1153,17 @@ function hbjs(Module) {
         var positionsArray = Module.HEAP32.subarray(positionsPtr32, positionsPtr32 + this.getLength() * 5);
         var positions = [];
         for (var i = 0; i < positionsArray.length; i += 5) {
-          positions.push({
+          var position = {
             x_advance: positionsArray[i],
             y_advance: positionsArray[i + 1],
             x_offset: positionsArray[i + 2],
             y_offset: positionsArray[i + 3],
+          };
+          Object.defineProperty(position, 'var', {
+            value: positionsArray[i + 4],
+            enumerable: false
           });
+          positions.push(position);
         }
         return positions;
       },

--- a/test/index.js
+++ b/test/index.js
@@ -687,6 +687,27 @@ describe('Buffer', function () {
     ]);
   });
 
+  it('glyph infos and positions have private properties', function () {
+    blob = hb.createBlob(fs.readFileSync(path.join(__dirname, 'fonts/noto/NotoSans-Regular.ttf')));
+    face = hb.createFace(blob);
+    font = hb.createFont(face);
+    buffer = hb.createBuffer();
+    buffer.addText('fi');
+    buffer.guessSegmentProperties();
+    hb.shape(font, buffer);
+    const infos = buffer.getGlyphInfos();
+    const positions = buffer.getGlyphPositions();
+
+    expect(infos.length).to.equal(1);
+    expect(positions.length).to.equal(1);
+    expect(Object.keys(infos[0])).to.deep.equal(['codepoint', 'cluster']);
+    expect(Object.keys(positions[0])).to.deep.equal(['x_advance', 'y_advance', 'x_offset', 'y_offset']);
+    expect(infos[0].mask).to.not.be.undefined;
+    expect(infos[0].var1).to.not.be.undefined;
+    expect(infos[0].var2).to.not.be.undefined;
+    expect(positions[0].var).to.not.be.undefined;
+  });
+
   it('getPositions returns empty array for buffer without positions', function () {
     blob = hb.createBlob(fs.readFileSync(path.join(__dirname, 'fonts/noto/NotoSans-Regular.ttf')));
     face = hb.createFace(blob);
@@ -993,3 +1014,4 @@ describe('misc', function () {
     }
   });
 });
+


### PR DESCRIPTION
Expose them as non-enumerable properties for clients who might need them.