### PR TITLE
Simplify importing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ Download from the [releases tab](https://github.com/harfbuzz/harfbuzzjs/releases
 ### TL;DR
 
 ```javascript
-import harfbuzz from "harfbuzzjs";
-const hb = await harfbuzz;
+import * as hb from "harfbuzzjs";
 
 const fontdata = await fetch('myfont.ttf').then(r => r.arrayBuffer());
 const blob = new hb.Blob(fontdata);      // Load the font data into Harfbuzz blob

--- a/demo/index.html
+++ b/demo/index.html
@@ -4,8 +4,7 @@
 <p><a id="svgResult" href="#" title="Click to download"></a></p>
 <p>Result:<div id="shapeResult"></div></p>
 <script type="module">
-import harfbuzz from './index.mjs';
-const hb = await harfbuzz;
+import * as hb from './index.mjs';
 
 var fontBlob;
 function updateResult() {

--- a/examples/harfbuzz.example.html
+++ b/examples/harfbuzz.example.html
@@ -1,6 +1,5 @@
 <script type="module">
-import harfbuzz from '../dist/index.mjs';
-const hb = await harfbuzz;
+import * as hb from '../dist/index.mjs';
 
 fetch('../test/fonts/noto/NotoSans-Regular.ttf')
   .then(x => x.arrayBuffer())

--- a/examples/harfbuzz.example.node.js
+++ b/examples/harfbuzz.example.node.js
@@ -1,20 +1,19 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import harfbuzz from '../dist/index.mjs';
+import { Blob, Face, Font, Buffer, shape } from '../dist/index.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const hb = await harfbuzz;
 
 function example(fontPath, text) {
-  var blob = new hb.Blob(fs.readFileSync(fontPath));
-  var face = new hb.Face(blob, 0);
-  var font = new hb.Font(face);
+  var blob = new Blob(fs.readFileSync(fontPath));
+  var face = new Face(blob, 0);
+  var font = new Font(face);
 
-  var buffer = new hb.Buffer();
+  var buffer = new Buffer();
   buffer.addText(text || 'abc');
   buffer.guessSegmentProperties();
-  hb.shape(font, buffer);
+  shape(font, buffer);
   var result = buffer.json(font);
 
   return result;

--- a/src/harfbuzz.d.ts
+++ b/src/harfbuzz.d.ts
@@ -1,2 +1,4 @@
-declare function createHarfBuzz(): Promise<EmscriptenModule>;
+import type { HarfBuzzModule } from "./index.mjs";
+
+declare function createHarfBuzz(): Promise<HarfBuzzModule>;
 export default createHarfBuzz;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -21,9 +21,9 @@ export const registry = new FinalizationRegistry<() => void>((cleanup) => {
 });
 
 /**
- * Initialize the HarfBuzz module. Must be called (and awaited) before
- * using any other functions or classes.
- * @param module The Emscripten module instance.
+ * Initialize the HarfBuzz module.
+ * @param module The Emscripten module instance created with {@link
+ * createHarfBuzz}.
  */
 export function init(module: EmscriptenModule) {
   Module = module as HarfBuzzModule;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -25,8 +25,8 @@ export const registry = new FinalizationRegistry<() => void>((cleanup) => {
  * @param module The Emscripten module instance created with {@link
  * createHarfBuzz}.
  */
-export function init(module: EmscriptenModule) {
-  Module = module as HarfBuzzModule;
+export function init(module: HarfBuzzModule) {
+  Module = module;
   exports = Module.wasmExports;
   freeFuncPtr = Module.addFunction((ptr: number) => {
     exports.free(ptr);

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,4 @@ export * from "./font-funcs";
 export * from "./buffer";
 export * from "./shape";
 
-export default createHarfBuzz().then(async (module) => {
-  init(module);
-  return await import("./index");
-});
+init(await createHarfBuzz());

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import createHarfBuzz from "./harfbuzz.js";
 import { init } from "./helpers";
 
-export { init } from "./helpers";
+export { createHarfBuzz, init };
 export * from "./types";
 export * from "./blob";
 export * from "./face";

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,16 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { expect, describe, it, beforeAll } from "vitest";
-import harfbuzz from "../dist/index.mjs";
+import { expect, describe, it } from "vitest";
+import * as hb from "../dist/index.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
-let hb;
-
-beforeAll(async function () {
-  hb = await harfbuzz;
-});
 
 describe("Face", function () {
   it("collectUnicodes reflects codepoints supported by the font", function () {

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -7,4 +7,5 @@ export default defineConfig({
   clean: false,
   outDir: "dist",
   deps: { neverBundle: ["./harfbuzz.js"] },
+  copy: ["src/harfbuzz.d.ts"],
 });


### PR DESCRIPTION
Do WASM initialization at module load time, so that explicit await is not needed:

    import * as hb from "harfbuzzjs";
    let face = new hb.Face(new hb.Blob(data));

or:

    import {Blob, Face} from "harfbuzzjs";
    let face = new Face(new Blob(data));