### PR TITLE
Replace TS enums with const objects + derived union types

### DIFF
--- a/src/buffer.ts
+++ b/src/buffer.ts
@@ -10,46 +10,57 @@ import {
 import type { GlyphInfo, GlyphPosition, JsonGlyph } from "./types";
 import { Font } from "./font";
 
-export enum BufferContentType {
-  INVALID = 0,
-  UNICODE = 1,
-  GLYPHS = 2,
-}
+export const BufferContentType = {
+  INVALID: 0,
+  UNICODE: 1,
+  GLYPHS: 2,
+} as const;
+export type BufferContentType =
+  (typeof BufferContentType)[keyof typeof BufferContentType];
 
-export enum BufferSerializeFlag {
-  DEFAULT = 0x00000000,
-  NO_CLUSTERS = 0x00000001,
-  NO_POSITIONS = 0x00000002,
-  NO_GLYPH_NAMES = 0x00000004,
-  GLYPH_EXTENTS = 0x00000008,
-  GLYPH_FLAGS = 0x00000010,
-  NO_ADVANCES = 0x00000020,
-}
+export const BufferSerializeFlag = {
+  DEFAULT: 0x00000000,
+  NO_CLUSTERS: 0x00000001,
+  NO_POSITIONS: 0x00000002,
+  NO_GLYPH_NAMES: 0x00000004,
+  GLYPH_EXTENTS: 0x00000008,
+  GLYPH_FLAGS: 0x00000010,
+  NO_ADVANCES: 0x00000020,
+  DEFINED: 0x0000003f,
+} as const;
+export type BufferSerializeFlag =
+  (typeof BufferSerializeFlag)[keyof typeof BufferSerializeFlag];
 
-export enum BufferFlag {
-  DEFAULT = 0x00000000,
-  BOT = 0x00000001,
-  EOT = 0x00000002,
-  PRESERVE_DEFAULT_IGNORABLES = 0x00000004,
-  REMOVE_DEFAULT_IGNORABLES = 0x00000008,
-  DO_NOT_INSERT_DOTTED_CIRCLE = 0x00000010,
-  VERIFY = 0x00000020,
-  PRODUCE_UNSAFE_TO_CONCAT = 0x00000040,
-  PRODUCE_SAFE_TO_INSERT_TATWEEL = 0x00000080,
-}
+export const BufferFlag = {
+  DEFAULT: 0x00000000,
+  BOT: 0x00000001,
+  EOT: 0x00000002,
+  PRESERVE_DEFAULT_IGNORABLES: 0x00000004,
+  REMOVE_DEFAULT_IGNORABLES: 0x00000008,
+  DO_NOT_INSERT_DOTTED_CIRCLE: 0x00000010,
+  VERIFY: 0x00000020,
+  PRODUCE_UNSAFE_TO_CONCAT: 0x00000040,
+  PRODUCE_SAFE_TO_INSERT_TATWEEL: 0x00000080,
+  DEFINED: 0x000000ff,
+} as const;
+export type BufferFlag = (typeof BufferFlag)[keyof typeof BufferFlag];
 
-export enum Direction {
-  INVALID = 0,
-  LTR = 4,
-  RTL = 5,
-  TTB = 6,
-  BTT = 7,
-}
+export const Direction = {
+  INVALID: 0,
+  LTR: 4,
+  RTL: 5,
+  TTB: 6,
+  BTT: 7,
+} as const;
+export type Direction = (typeof Direction)[keyof typeof Direction];
 
-export enum BufferSerializeFormat {
-  TEXT = "TEXT",
-  JSON = "JSON",
-}
+export const BufferSerializeFormat = {
+  INVALID: 0,
+  TEXT: hb_tag("TEXT"),
+  JSON: hb_tag("JSON"),
+} as const;
+export type BufferSerializeFormat =
+  (typeof BufferSerializeFormat)[keyof typeof BufferSerializeFormat];
 
 /**
  * An object representing a {@link https://harfbuzz.github.io/harfbuzz-hb-buffer.html | HarfBuzz buffer}.
@@ -384,7 +395,7 @@ export class Buffer {
         bufLen,
         bufConsumedPtr,
         font ? font.ptr : 0,
-        hb_tag(format),
+        format,
         flags,
       );
       const bufConsumed = Module.HEAPU32[bufConsumedPtr / 4];

--- a/src/face.ts
+++ b/src/face.ts
@@ -15,13 +15,14 @@ import type { Blob } from "./blob";
 
 const HB_OT_NAME_ID_INVALID = 0xffff;
 
-export enum GlyphClass {
-  UNCLASSIFIED = 0,
-  BASE_GLYPH = 1,
-  LIGATURE = 2,
-  MARK = 3,
-  COMPONENT = 4,
-}
+export const GlyphClass = {
+  UNCLASSIFIED: 0,
+  BASE_GLYPH: 1,
+  LIGATURE: 2,
+  MARK: 3,
+  COMPONENT: 4,
+} as const;
+export type GlyphClass = (typeof GlyphClass)[keyof typeof GlyphClass];
 
 /**
  * An object representing a {@link https://harfbuzz.github.io/harfbuzz-hb-face.html | HarfBuzz face}.

--- a/src/shape.ts
+++ b/src/shape.ts
@@ -16,11 +16,12 @@ import {
   BufferSerializeFlag,
 } from "./buffer";
 
-export enum TracePhase {
-  DONT_STOP = 0,
-  GSUB = 1,
-  GPOS = 2,
-}
+export const TracePhase = {
+  DONT_STOP: 0,
+  GSUB: 1,
+  GPOS: 2,
+} as const;
+export type TracePhase = (typeof TracePhase)[keyof typeof TracePhase];
 
 /**
  * Shape a buffer with a given font.
@@ -78,7 +79,7 @@ export function shapeWithTrace(
   stop_phase: TracePhase,
 ): TraceEntry[] {
   const trace: TraceEntry[] = [];
-  let currentPhase = TracePhase.DONT_STOP;
+  let currentPhase: TracePhase = TracePhase.DONT_STOP;
   let stopping = false;
 
   buffer.setMessageFunc((buffer, font, message) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,9 +86,10 @@ export interface HarfBuzzModule extends EmscriptenModule {
   stackRestore(ptr: number): void;
 }
 
-export enum GlyphFlag {
-  UNSAFE_TO_BREAK = 0x00000001,
-  UNSAFE_TO_CONCAT = 0x00000002,
-  SAFE_TO_INSERT_TATWEEL = 0x00000004,
-  DEFINED = 0x00000007,
-}
+export const GlyphFlag = {
+  UNSAFE_TO_BREAK: 0x00000001,
+  UNSAFE_TO_CONCAT: 0x00000002,
+  SAFE_TO_INSERT_TATWEEL: 0x00000004,
+  DEFINED: 0x00000007,
+} as const;
+export type GlyphFlag = (typeof GlyphFlag)[keyof typeof GlyphFlag];


### PR DESCRIPTION
* Fixes https://github.com/harfbuzz/harfbuzzjs/issues/190

I did not use union type for `BufferSerializeForma`t though, because the underlying C value is an integer, and it has an `INVALID` value that we didn’t support before. I now use integers instead of strings for it.