### PR TITLE
Update copyright and license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,4 @@
-Apache license for Zephyr libc implementations (zephyr-string.c),
-emmalloc.cpp (from emscripten project) and MIT for rest of the project
-
-Copyright (c) 2019 Ebrahim Byagowi
+Copyright (c) 2019-2026 The harfbuzzjs project authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ test: all typecheck
 	node examples/harfbuzz-subset.example.node.js
 
 doc: node_modules
-	npx typedoc src/index.ts --projectDocuments MIGRATING.md --headings.readme false --treatWarningsAsErrors --out docs
+	npx typedoc
 
 clean:
 	rm -rf dist

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "type": "git",
     "url": "git+https://github.com/harfbuzz/harfbuzzjs.git"
   },
-  "author": "Ebrahim Byagowi <ebrahim@gnu.org>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/harfbuzz/harfbuzzjs/issues"

--- a/package.json
+++ b/package.json
@@ -37,10 +37,8 @@
     "url": "git+https://github.com/harfbuzz/harfbuzzjs.git"
   },
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/harfbuzz/harfbuzzjs/issues"
-  },
-  "homepage": "https://github.com/harfbuzz/harfbuzzjs#readme",
+  "bugs": "https://github.com/harfbuzz/harfbuzzjs/issues",
+  "homepage": "https://harfbuzz.github.io/harfbuzzjs",
   "devDependencies": {
     "@types/emscripten": "^1.41.5",
     "@types/node": "^25.5.0",

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "navigationLinks": {
+    "GitHub": "https://github.com/harfbuzz/harfbuzzjs"
+  }
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,5 +1,12 @@
 {
+  "entryPoints": ["src/index.ts"],
+  "projectDocuments": ["MIGRATING.md"],
+  "headings": {
+    "readme": false
+  },
   "navigationLinks": {
     "GitHub": "https://github.com/harfbuzz/harfbuzzjs"
-  }
+  },
+  "treatWarningsAsErrors": true,
+  "out": "docs"
 }


### PR DESCRIPTION
* Fixes https://github.com/harfbuzz/harfbuzzjs/issues/192

Make the copyright holders “The harfbuzzjs project authors” for simplicity.

Drop the author field from `package.json` as it can only include one author (there is the alternative contributors field, but I don’t want to keep adding people to it, there is git history for anyone who cares).