### PR TITLE
Drop Buffer.json()

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -66,7 +66,7 @@ The deprecated `flags` field has been removed. Use `fl` instead, which is also `
 
 Affected APIs:
 
-- `Buffer.serialize(font, start, end, …)`: `font` and `end` accept `undefined` (or omission), instead of `null`.
+- `Buffer.serialize` now takes a single options object: `{ font, start, end, format, flags }` (all optional). The previous positional signature is gone.
 - `Buffer.addText` / `Buffer.addCodePoints`: `itemLength` accepts `undefined` (or omission), instead of `null`.
 - `Face.getFeatureNameIds`: returns `undefined` on failure, instead of `null`.
 - `Font.glyphHOrigin` / `glyphVOrigin` / `glyphExtents` / `glyphFromName`: return `undefined` on failure, instead of `null`.

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -51,14 +51,15 @@ values exported from the package.
 | `GlyphPosition.x_offset`        | `GlyphPosition.xOffset`        |
 | `GlyphPosition.y_offset`        | `GlyphPosition.yOffset`        |
 
-### `Buffer.json()`
+### `Buffer.json()` removed
 
-The deprecated `flags` field has been removed. Use `fl` instead, which is also `undefined` (not `0`) when no flags are set.
+The `Buffer.json()` shortcut has been removed. Use the typed accessors instead:
 
-| v0.x                            | v1.x                                         |
-| ------------------------------- | -------------------------------------------- |
-| `buffer.json()[0].flags` → `0`  | `buffer.json()[0].fl` → `undefined`          |
-| `buffer.json()[0].flags` → bits | `buffer.json()[0].fl` → bits (`GlyphFlag`)   |
+- `Buffer.getGlyphInfos()` for glyph IDs, clusters, and flags.
+- `Buffer.getGlyphPositions()` for advances and offsets.
+- `Buffer.getGlyphInfosAndPositions()` for both combined.
+
+When you need the raw HarfBuzz JSON output (e.g. to capture all fields including glyph names), call `Buffer.serialize()` with `BufferSerializeFormat.JSON` and `JSON.parse()` the result yourself.
 
 ## `null` replaced with `undefined`
 

--- a/examples/harfbuzz.example.html
+++ b/examples/harfbuzz.example.html
@@ -13,14 +13,14 @@
       buffer.guessSegmentProperties();
       hb.shape(font, buffer);
 
-      var result = buffer.json(font);
+      var result = buffer.getGlyphInfosAndPositions();
       var glyphs = {};
       result.forEach(function (x) {
-        if (glyphs[x.g]) return;
-        glyphs[x.g] = {
-          name: font.glyphName(x.g),
-          path: font.glyphToPath(x.g),
-          json: font.glyphToJson(x.g),
+        if (glyphs[x.codepoint]) return;
+        glyphs[x.codepoint] = {
+          name: font.glyphName(x.codepoint),
+          path: font.glyphToPath(x.codepoint),
+          json: font.glyphToJson(x.codepoint),
         };
       });
 

--- a/examples/harfbuzz.example.js
+++ b/examples/harfbuzz.example.js
@@ -11,16 +11,16 @@ function example(hb, fontBlob, text) {
   buffer.guessSegmentProperties();
   // buffer.setDirection(hb.Direction.LTR); // optional as can be set by guessSegmentProperties also
   hb.shape(font, buffer); // features are not supported yet
-  var result = buffer.json(font);
+  var result = buffer.getGlyphInfosAndPositions();
 
   // returns glyphs paths, totally optional
   var glyphs = {};
   result.forEach(function (x) {
-    if (glyphs[x.g]) return;
-    glyphs[x.g] = {
-      name: font.glyphName(x.g),
-      path: font.glyphToPath(x.g),
-      json: font.glyphToJson(x.g),
+    if (glyphs[x.codepoint]) return;
+    glyphs[x.codepoint] = {
+      name: font.glyphName(x.codepoint),
+      path: font.glyphToPath(x.codepoint),
+      json: font.glyphToJson(x.codepoint),
     };
   });
 

--- a/examples/harfbuzz.example.node.js
+++ b/examples/harfbuzz.example.node.js
@@ -14,9 +14,8 @@ function example(fontPath, text) {
   buffer.addText(text || "abc");
   buffer.guessSegmentProperties();
   shape(font, buffer);
-  var result = buffer.json(font);
 
-  return result;
+  return buffer.getGlyphInfosAndPositions();
 }
 
 console.log(

--- a/src/buffer.ts
+++ b/src/buffer.ts
@@ -237,16 +237,17 @@ export class Buffer {
    * @returns An array of {@link GlyphInfo} objects.
    */
   getGlyphInfos(): GlyphInfo[] {
-    const infosPtr32 = exports.hb_buffer_get_glyph_infos(this.ptr, 0) / 4;
+    const infosPtr = exports.hb_buffer_get_glyph_infos(this.ptr, 0);
     const infosArray = Module.HEAPU32.subarray(
-      infosPtr32,
-      infosPtr32 + this.getLength() * 5,
+      infosPtr / 4,
+      infosPtr / 4 + this.getLength() * 5,
     );
     const infos: GlyphInfo[] = [];
     for (let i = 0; i < infosArray.length; i += 5) {
       infos.push({
         codepoint: infosArray[i],
         cluster: infosArray[i + 2],
+        flags: exports.hb_glyph_info_get_glyph_flags(infosPtr + i * 4),
       });
     }
     return infos;
@@ -286,10 +287,10 @@ export class Buffer {
    * properties from getGlyphInfos and getGlyphPositions combined.
    */
   getGlyphInfosAndPositions(): (GlyphInfo & Partial<GlyphPosition>)[] {
-    const infosPtr32 = exports.hb_buffer_get_glyph_infos(this.ptr, 0) / 4;
+    const infosPtr = exports.hb_buffer_get_glyph_infos(this.ptr, 0);
     const infosArray = Module.HEAPU32.subarray(
-      infosPtr32,
-      infosPtr32 + this.getLength() * 5,
+      infosPtr / 4,
+      infosPtr / 4 + this.getLength() * 5,
     );
 
     const positionsPtr32 =
@@ -306,6 +307,7 @@ export class Buffer {
       const info: GlyphInfo & Partial<GlyphPosition> = {
         codepoint: infosArray[i],
         cluster: infosArray[i + 2],
+        flags: exports.hb_glyph_info_get_glyph_flags(infosPtr + i * 4),
       };
       for (const [name, idx] of [
         ["mask", 1],

--- a/src/buffer.ts
+++ b/src/buffer.ts
@@ -359,21 +359,27 @@ export class Buffer {
 
   /**
    * Serialize the buffer contents to a string.
-   * @param font The font to use for serialization.
-   * @param start The starting index of the glyphs to serialize.
-   * @param end The ending index of the glyphs to serialize.
-   * @param format The {@link BufferSerializeFormat} to serialize the buffer contents to.
-   * @param flags A combination of {@link BufferSerializeFlag} values (OR them together).
-   *
+   * @param options Serialization options:
+   *  - `font`: the font to use for serialization;
+   *  - `start`: the starting index of the glyphs (default `0`);
+   *  - `end`: the ending index of the glyphs (default end of buffer);
+   *  - `format`: a {@link BufferSerializeFormat} value (default `TEXT`);
+   *  - `flags`: a combination of {@link BufferSerializeFlag} values (default `0`).
    * @returns The serialized buffer contents.
    */
   serialize(
-    font?: Font,
-    start: number = 0,
-    end?: number,
-    format: BufferSerializeFormat = BufferSerializeFormat.TEXT,
-    flags: number = 0,
+    options: {
+      font?: Font;
+      start?: number;
+      end?: number;
+      format?: BufferSerializeFormat;
+      flags?: number;
+    } = {},
   ): string {
+    let { font, start, end, format, flags } = options;
+    start ??= 0;
+    format ??= BufferSerializeFormat.TEXT;
+    flags ??= 0;
     const sp = Module.stackSave();
     const endPos = end ?? this.getLength();
     const bufLen = 32 * 1024;
@@ -415,13 +421,11 @@ export class Buffer {
    * @returns An array of {@link JsonGlyph} objects.
    */
   json(): JsonGlyph[] {
-    const buf = this.serialize(
-      undefined,
-      0,
-      undefined,
-      BufferSerializeFormat.JSON,
-      BufferSerializeFlag.NO_GLYPH_NAMES | BufferSerializeFlag.GLYPH_FLAGS,
-    );
+    const buf = this.serialize({
+      format: BufferSerializeFormat.JSON,
+      flags:
+        BufferSerializeFlag.NO_GLYPH_NAMES | BufferSerializeFlag.GLYPH_FLAGS,
+    });
     return JSON.parse(buf);
   }
 }

--- a/src/buffer.ts
+++ b/src/buffer.ts
@@ -8,7 +8,7 @@ import {
   string_to_utf16_ptr,
   type ValueOf,
 } from "./helpers";
-import type { GlyphInfo, GlyphPosition, JsonGlyph } from "./types";
+import type { GlyphInfo, GlyphPosition } from "./types";
 import { Font } from "./font";
 
 export const BufferContentType = {
@@ -414,18 +414,5 @@ export class Buffer {
    */
   getContentType(): BufferContentType {
     return exports.hb_buffer_get_content_type(this.ptr) as BufferContentType;
-  }
-
-  /**
-   * Return the buffer contents as a JSON object.
-   * @returns An array of {@link JsonGlyph} objects.
-   */
-  json(): JsonGlyph[] {
-    const buf = this.serialize({
-      format: BufferSerializeFormat.JSON,
-      flags:
-        BufferSerializeFlag.NO_GLYPH_NAMES | BufferSerializeFlag.GLYPH_FLAGS,
-    });
-    return JSON.parse(buf);
   }
 }

--- a/src/shape.ts
+++ b/src/shape.ts
@@ -99,13 +99,11 @@ export function shapeWithTrace(
 
     if (stopping) return false;
 
-    const traceBuf = buffer.serialize(
+    const traceBuf = buffer.serialize({
       font,
-      0,
-      undefined,
-      BufferSerializeFormat.JSON,
-      BufferSerializeFlag.NO_GLYPH_NAMES,
-    );
+      format: BufferSerializeFormat.JSON,
+      flags: BufferSerializeFlag.NO_GLYPH_NAMES,
+    });
 
     trace.push({
       m: message,

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,8 @@ export interface GlyphInfo {
   codepoint: number;
   /** The cluster index of the glyph. */
   cluster: number;
+  /** Glyph flags, a combination of {@link GlyphFlag} values. */
+  flags: number;
 }
 
 export interface GlyphPosition {

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,23 +34,6 @@ export interface GlyphPosition {
   yOffset: number;
 }
 
-export interface JsonGlyph {
-  /** The glyph ID. */
-  g: number;
-  /** The cluster ID. */
-  cl: number;
-  /** Advance width (width to advance after this glyph is painted). */
-  ax: number;
-  /** Advance height (height to advance after this glyph is painted). */
-  ay: number;
-  /** X displacement (adjustment in X dimension when painting this glyph). */
-  dx: number;
-  /** Y displacement (adjustment in Y dimension when painting this glyph). */
-  dy: number;
-  /** Glyph flags, a combination of {@link GlyphFlag} values. */
-  fl: number;
-}
-
 export interface SvgPathCommand {
   type: string;
   values: number[];

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -427,8 +427,8 @@ describe("Font", function () {
     buffer.guessSegmentProperties();
     font.setScale(1000 * 2, 1000 * 2);
     hb.shape(font, buffer);
-    const glyphs = buffer.json();
-    expect(glyphs[0].ax).to.equal(561 * 2);
+    const positions = buffer.getGlyphPositions();
+    expect(positions[0].xAdvance).to.equal(561 * 2);
   });
 
   it("glyphExtents returns extents for glyph ids", function () {
@@ -504,8 +504,8 @@ describe("Font", function () {
     buffer.addText("آلو");
     buffer.guessSegmentProperties();
     hb.shape(font, buffer);
-    const glyphs = buffer.json();
-    expect(glyphs[0].ax).to.equal(526);
+    const positions = buffer.getGlyphPositions();
+    expect(positions[0].xAdvance).to.equal(526);
   });
 
   it("glyphToPath converts quadratic glyph to path", function () {
@@ -690,9 +690,9 @@ describe("FontFuncs", function () {
     buffer.addText("12");
     buffer.guessSegmentProperties();
     hb.shape(font, buffer);
-    const glyphs = buffer.json();
-    expect(glyphs[0].g).to.equal(21);
-    expect(glyphs[1].g).to.equal(22);
+    const infos = buffer.getGlyphInfos();
+    expect(infos[0].codepoint).to.equal(21);
+    expect(infos[1].codepoint).to.equal(22);
   });
 
   it("setVariationGlyphFunc", function () {
@@ -717,10 +717,10 @@ describe("FontFuncs", function () {
     buffer.addText("11\uFE002\uFE00");
     buffer.guessSegmentProperties();
     hb.shape(font, buffer);
-    const glyphs = buffer.json();
-    expect(glyphs[0].g).to.equal(21);
-    expect(glyphs[1].g).to.equal(23);
-    expect(glyphs[2].g).to.equal(22);
+    const infos = buffer.getGlyphInfos();
+    expect(infos[0].codepoint).to.equal(21);
+    expect(infos[1].codepoint).to.equal(23);
+    expect(infos[2].codepoint).to.equal(22);
   });
 
   it("setFontHExtentsFunc", function () {
@@ -781,10 +781,10 @@ describe("Buffer", function () {
     buffer.addText("rtl");
     buffer.setDirection(hb.Direction.RTL);
     hb.shape(font, buffer);
-    const glyphs = buffer.json();
-    expect(glyphs[0].g).to.equal(79); // l
-    expect(glyphs[1].g).to.equal(87); // t
-    expect(glyphs[2].g).to.equal(85); // r
+    const infos = buffer.getGlyphInfos();
+    expect(infos[0].codepoint).to.equal(79); // l
+    expect(infos[1].codepoint).to.equal(87); // t
+    expect(infos[2].codepoint).to.equal(85); // r
   });
 
   it("setClusterLevel affects cluster merging", function () {
@@ -798,9 +798,9 @@ describe("Buffer", function () {
     buffer.addText("x́");
     buffer.guessSegmentProperties();
     hb.shape(font, buffer);
-    const glyphs = buffer.json();
-    expect(glyphs[0].cl).to.equal(0);
-    expect(glyphs[1].cl).to.equal(1);
+    const infos = buffer.getGlyphInfos();
+    expect(infos[0].cluster).to.equal(0);
+    expect(infos[1].cluster).to.equal(1);
   });
 
   it("setFlags with PRESERVE_DEFAULT_IGNORABLES affects glyph ids", function () {
@@ -814,8 +814,8 @@ describe("Buffer", function () {
     buffer.setFlags(hb.BufferFlag.PRESERVE_DEFAULT_IGNORABLES);
     buffer.guessSegmentProperties();
     hb.shape(font, buffer);
-    const glyphs = buffer.json();
-    expect(glyphs[0].g).not.to.equal(3 /* space */);
+    const infos = buffer.getGlyphInfos();
+    expect(infos[0].codepoint).not.to.equal(3); // space
   });
 
   it("setFlags ignores invalid flags", function () {
@@ -829,8 +829,8 @@ describe("Buffer", function () {
     buffer.setFlags(0);
     buffer.guessSegmentProperties();
     hb.shape(font, buffer);
-    const glyphs = buffer.json();
-    expect(glyphs[0].g).to.equal(68 /* a */);
+    const infos = buffer.getGlyphInfos();
+    expect(infos[0].codepoint).to.equal(68); // a
   });
 
   it("setFlags with PRODUCE_SAFE_TO_INSERT_TATWEEL affects glyph flags", function () {
@@ -846,16 +846,16 @@ describe("Buffer", function () {
     buffer.setFlags(hb.BufferFlag.PRODUCE_SAFE_TO_INSERT_TATWEEL);
     buffer.guessSegmentProperties();
     hb.shape(font, buffer);
-    const flags = Array.from(buffer.json().map((g) => g.fl));
-    expect(flags).to.deep.equal([5, undefined]);
+    const flags = buffer.getGlyphInfos().map((g) => g.flags);
+    expect(flags).to.deep.equal([5, 0]);
 
     buffer.clearContents();
     buffer.addText("بلا");
     buffer.setFlags(0);
     buffer.guessSegmentProperties();
     hb.shape(font, buffer);
-    const flags2 = Array.from(buffer.json().map((g) => g.fl));
-    expect(flags2).to.deep.equal([1, undefined]);
+    const flags2 = buffer.getGlyphInfos().map((g) => g.flags);
+    expect(flags2).to.deep.equal([1, 0]);
   });
 
   it("serialize ignores invalid flags", function () {
@@ -1091,7 +1091,15 @@ describe("shape", function () {
     buffer.addText("abc");
     buffer.guessSegmentProperties();
     hb.shape(font, buffer);
-    const glyphs = buffer.json();
+    const glyphs = JSON.parse(
+      buffer.serialize({
+        font,
+        format: hb.BufferSerializeFormat.JSON,
+        flags:
+          hb.BufferSerializeFlag.NO_GLYPH_NAMES |
+          hb.BufferSerializeFlag.GLYPH_FLAGS,
+      }),
+    );
     expect(glyphs[0]).to.deep.equal(
       { cl: 0, g: 68, ax: 561, ay: 0, dx: 0, dy: 0 } /* a */,
     );
@@ -1113,7 +1121,15 @@ describe("shape", function () {
     buffer.addCodePoints([..."abc"].map((c) => c.codePointAt(0)));
     buffer.guessSegmentProperties();
     hb.shape(font, buffer);
-    const glyphs = buffer.json();
+    const glyphs = JSON.parse(
+      buffer.serialize({
+        font,
+        format: hb.BufferSerializeFormat.JSON,
+        flags:
+          hb.BufferSerializeFlag.NO_GLYPH_NAMES |
+          hb.BufferSerializeFlag.GLYPH_FLAGS,
+      }),
+    );
     expect(glyphs[0]).to.deep.equal(
       { cl: 0, g: 68, ax: 561, ay: 0, dx: 0, dy: 0 } /* a */,
     );
@@ -1137,7 +1153,15 @@ describe("shape", function () {
     buffer.addText("أبجد");
     buffer.guessSegmentProperties();
     hb.shape(font, buffer);
-    const glyphs = buffer.json();
+    const glyphs = JSON.parse(
+      buffer.serialize({
+        font,
+        format: hb.BufferSerializeFormat.JSON,
+        flags:
+          hb.BufferSerializeFlag.NO_GLYPH_NAMES |
+          hb.BufferSerializeFlag.GLYPH_FLAGS,
+      }),
+    );
     expect(glyphs[0]).to.deep.equal(
       { cl: 3, g: 213, ax: 532, ay: 0, dx: 0, dy: 0, fl: 1 } /* د */,
     );
@@ -1164,7 +1188,15 @@ describe("shape", function () {
     buffer.addText("أبجد", 1, 2);
     buffer.guessSegmentProperties();
     hb.shape(font, buffer);
-    const glyphs = buffer.json();
+    const glyphs = JSON.parse(
+      buffer.serialize({
+        font,
+        format: hb.BufferSerializeFormat.JSON,
+        flags:
+          hb.BufferSerializeFlag.NO_GLYPH_NAMES |
+          hb.BufferSerializeFlag.GLYPH_FLAGS,
+      }),
+    );
     expect(glyphs[0]).to.deep.equal(
       { cl: 2, g: 529, ax: 637, ay: 0, dx: 0, dy: 0, fl: 1 } /* ج */,
     );
@@ -1189,7 +1221,15 @@ describe("shape", function () {
     );
     buffer.guessSegmentProperties();
     hb.shape(font, buffer);
-    const glyphs = buffer.json();
+    const glyphs = JSON.parse(
+      buffer.serialize({
+        font,
+        format: hb.BufferSerializeFormat.JSON,
+        flags:
+          hb.BufferSerializeFlag.NO_GLYPH_NAMES |
+          hb.BufferSerializeFlag.GLYPH_FLAGS,
+      }),
+    );
     expect(glyphs[0]).to.deep.equal(
       { cl: 2, g: 529, ax: 637, ay: 0, dx: 0, dy: 0, fl: 1 } /* ج */,
     );
@@ -1288,18 +1328,18 @@ describe("shape", function () {
     buffer.addText("५ल");
     buffer.guessSegmentProperties();
     hb.shape(font, buffer);
-    var glyphs = buffer.json();
-    expect(glyphs).to.have.lengthOf(2);
-    expect(glyphs[0].g).to.equal(118);
+    var infos = buffer.getGlyphInfos();
+    expect(infos).to.have.lengthOf(2);
+    expect(infos[0].codepoint).to.equal(118);
 
     buffer.clearContents();
     buffer.addText("५ल");
     buffer.setLanguage("dty");
     buffer.guessSegmentProperties();
     hb.shape(font, buffer);
-    var glyphs = buffer.json();
-    expect(glyphs).to.have.lengthOf(2);
-    expect(glyphs[0].g).to.equal(123);
+    var infos = buffer.getGlyphInfos();
+    expect(infos).to.have.lengthOf(2);
+    expect(infos[0].codepoint).to.equal(123);
   });
 
   it("shape with OpenType language tag", function () {
@@ -1314,18 +1354,18 @@ describe("shape", function () {
     buffer.addText("५ल");
     buffer.guessSegmentProperties();
     hb.shape(font, buffer);
-    var glyphs = buffer.json();
-    expect(glyphs).to.have.lengthOf(2);
-    expect(glyphs[0].g).to.equal(118);
+    var infos = buffer.getGlyphInfos();
+    expect(infos).to.have.lengthOf(2);
+    expect(infos[0].codepoint).to.equal(118);
 
     buffer.clearContents();
     buffer.addText("५ल");
     buffer.setLanguage("x-hbot-4e455020"); // 'NEP '
     buffer.guessSegmentProperties();
     hb.shape(font, buffer);
-    var glyphs = buffer.json();
-    expect(glyphs).to.have.lengthOf(2);
-    expect(glyphs[0].g).to.equal(123);
+    var infos = buffer.getGlyphInfos();
+    expect(infos).to.have.lengthOf(2);
+    expect(infos[0].codepoint).to.equal(123);
   });
 });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -868,13 +868,10 @@ describe("Buffer", function () {
     buffer.addText("abc");
     buffer.guessSegmentProperties();
     hb.shape(font, buffer);
-    const glyphs = buffer.serialize(
+    const glyphs = buffer.serialize({
       font,
-      0,
-      undefined,
-      hb.BufferSerializeFormat.TEXT,
-      0,
-    );
+      format: hb.BufferSerializeFormat.TEXT,
+    });
     expect(glyphs).to.deep.equal("[a=0+561|b=1+615|c=2+480]");
   });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -936,10 +936,10 @@ describe("Buffer", function () {
     let infosAndPositions = buffer.getGlyphInfosAndPositions();
 
     expect(infos).to.deep.equal([
-      { codepoint: 120, cluster: 0 },
-      { codepoint: 768, cluster: 1 },
-      { codepoint: 102, cluster: 2 },
-      { codepoint: 105, cluster: 3 },
+      { codepoint: 120, cluster: 0, flags: 0 },
+      { codepoint: 768, cluster: 1, flags: 0 },
+      { codepoint: 102, cluster: 2, flags: 0 },
+      { codepoint: 105, cluster: 3, flags: 0 },
     ]);
     expect(positions).to.deep.equal([
       { xAdvance: 0, yAdvance: 0, xOffset: 0, yOffset: 0 },
@@ -962,9 +962,9 @@ describe("Buffer", function () {
     infosAndPositions = buffer.getGlyphInfosAndPositions();
 
     expect(infos).to.deep.equal([
-      { codepoint: 91, cluster: 0 },
-      { codepoint: 2662, cluster: 0 },
-      { codepoint: 1652, cluster: 2 },
+      { codepoint: 91, cluster: 0, flags: 0 },
+      { codepoint: 2662, cluster: 0, flags: 0 },
+      { codepoint: 1652, cluster: 2, flags: 0 },
     ]);
     expect(positions).to.deep.equal([
       { xAdvance: 529, yAdvance: 0, xOffset: 0, yOffset: 0 },
@@ -995,6 +995,7 @@ describe("Buffer", function () {
     expect(Object.keys(infosAndPositions[0])).to.deep.equal([
       "codepoint",
       "cluster",
+      "flags",
       "xAdvance",
       "yAdvance",
       "xOffset",


### PR DESCRIPTION
Avoid the potentially confusing `JsonGlyph` name, since we have two kinds of JSON output (shaping data and glyph outlines). Use an array type `SerializedBufferJson` for the whole output.

I realised also that `JsonGlyph` did not cover Unicode buffer (when serializing the buffer before shaping), so it now supports it, too.

* Closes https://github.com/harfbuzz/harfbuzzjs/issues/197