### PR TITLE
Allow `new Blob()` to accept Uint8Array directly

### DIFF
--- a/src/blob.ts
+++ b/src/blob.ts
@@ -11,7 +11,7 @@ export class Blob {
    * @param data Binary font data.
    */
   constructor(data: Uint8Array | ArrayBuffer) {
-    const array = data instanceof Uint8Array ? data : new Uint8Array(data)
+    const array = data instanceof Uint8Array ? data : new Uint8Array(data);
     const blobPtr = exports.malloc(array.byteLength);
     Module.HEAPU8.set(array, blobPtr);
     this.ptr = exports.hb_blob_create(

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -10,12 +10,13 @@ export class Blob {
   /**
    * @param data Binary font data.
    */
-  constructor(data: ArrayBuffer) {
-    const blobPtr = exports.malloc(data.byteLength);
-    Module.HEAPU8.set(new Uint8Array(data), blobPtr);
+  constructor(data: Uint8Array | ArrayBuffer) {
+    const array = data instanceof Uint8Array ? data : new Uint8Array(data)
+    const blobPtr = exports.malloc(array.byteLength);
+    Module.HEAPU8.set(array, blobPtr);
     this.ptr = exports.hb_blob_create(
       blobPtr,
-      data.byteLength,
+      array.byteLength,
       2 /* HB_MEMORY_MODE_WRITABLE */,
       blobPtr,
       freeFuncPtr,


### PR DESCRIPTION
Often an Uint8Array is already available. For example, Node.js Buffer is [compatible with Uint8Array](https://nodejs.org/api/buffer.html#buffers-and-typedarrays), and [.bytes()](https://developer.mozilla.org/en-US/docs/Web/API/Response/bytes) has also been recently added to the Response API in addition to .arrayBuffer() (see also the [background discussion](https://github.com/whatwg/fetch/issues/1732)).

Converting an Uint8Array to an ArrayBuffer can also be error-prone because of the sharing of an underlying ArrayBuffer (I just got bitten by this in the Unicode core spec’s codebase…). For example, instead of:

```ts
const arrayBuffer = readFileSync(path).buffer;
```

One must remember to do:

```ts
const buffer = readFileSync(path);
const arrayBuffer = buffer.buffer.slice(
  buffer.byteOffset,
  buffer.byteOffset + buffer.byteLength,
);
```

This PR also fixes the type error at:

https://github.com/harfbuzz/harfbuzzjs/blob/bced90bf856f8f24fbf7fb864984fc5c34a1f513/examples/harfbuzz.example.node.js#L9