### PR TITLE
Extend AxisInfo to cover all of hb_ot_var_axis_info_t

### DIFF
--- a/src/face.ts
+++ b/src/face.ts
@@ -77,7 +77,7 @@ export class Face {
 
   /**
    * Return variation axis infos.
-   * @returns A dictionary mapping axis tags to {min, default, max} values.
+   * @returns A dictionary mapping axis tags to {@link AxisInfo} values.
    */
   getAxisInfos(): Record<string, AxisInfo> {
     const sp = Module.stackSave();
@@ -87,11 +87,16 @@ export class Face {
     exports.hb_ot_var_get_axis_infos(this.ptr, 0, c, axis);
     const result: Record<string, AxisInfo> = {};
     Array.from({ length: Module.HEAPU32[c / 4] }).forEach((_, i) => {
-      result[hb_untag(Module.HEAPU32[axis / 4 + i * 8 + 1])] = {
+      const info: AxisInfo = {
+        axisIndex: Module.HEAPU32[axis / 4 + i * 8],
+        tag: hb_untag(Module.HEAPU32[axis / 4 + i * 8 + 1]),
+        nameId: Module.HEAPU32[axis / 4 + i * 8 + 2],
+        flags: Module.HEAPU32[axis / 4 + i * 8 + 3],
         min: Module.HEAPF32[axis / 4 + i * 8 + 4],
         default: Module.HEAPF32[axis / 4 + i * 8 + 5],
         max: Module.HEAPF32[axis / 4 + i * 8 + 6],
       };
+      result[info.tag] = info;
     });
     Module.stackRestore(sp);
     return result;

--- a/src/types.ts
+++ b/src/types.ts
@@ -273,9 +273,37 @@ export const PaintCompositeMode = {
 } as const;
 export type PaintCompositeMode = ValueOf<typeof PaintCompositeMode>;
 
+/** Flags for {@link AxisInfo}. */
+export const AxisFlags = {
+  /** The axis should not be exposed directly in user interfaces. */
+  HIDDEN: 0x00000001,
+} as const;
+export type AxisFlags = ValueOf<typeof AxisFlags>;
+
+/**
+ * Data type for holding variation-axis values.
+ *
+ * The minimum, default, and maximum values are in un-normalized, user scales.
+ */
 export interface AxisInfo {
+  /** Index of the axis in the variation-axis array. */
+  axisIndex: number;
+  /** The tag identifying the design variation of the axis. */
+  tag: string;
+  /** The `name` table Name ID that provides display names for the axis. */
+  nameId: number;
+  /**
+   * The {@link AxisFlags} flags for the axis.
+   *
+   * Note: at present, the only flag defined for `flags` is
+   * {@link AxisFlags.HIDDEN}.
+   */
+  flags: number;
+  /** The minimum value on the variation axis that the font covers. */
   min: number;
+  /** The position on the variation axis corresponding to the font's defaults. */
   default: number;
+  /** The maximum value on the variation axis that the font covers. */
   max: number;
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -33,8 +33,24 @@ describe("Face", function () {
     );
     let face = new hb.Face(blob);
     expect(face.getAxisInfos()).to.deep.equal({
-      wght: { min: 100, default: 400, max: 900 },
-      wdth: { min: 62.5, default: 100, max: 100 },
+      wght: {
+        axisIndex: 0,
+        tag: "wght",
+        nameId: 256,
+        flags: 0,
+        min: 100,
+        default: 400,
+        max: 900,
+      },
+      wdth: {
+        axisIndex: 1,
+        tag: "wdth",
+        nameId: 257,
+        flags: 0,
+        min: 62.5,
+        default: 100,
+        max: 100,
+      },
     });
   });
 


### PR DESCRIPTION
Expose axisIndex, tag, nameId and flags in addition to the min, default and max values, and add an AxisFlags enum for the flags.